### PR TITLE
Add Eclipse Store based ToDo and Achievement gateways

### DIFF
--- a/boundary-acceptance-test/build.gradle
+++ b/boundary-acceptance-test/build.gradle
@@ -16,11 +16,14 @@ dependencies {
     integrationTestImplementation project(':messaging')
     integrationTestImplementation project(':util-serialization')
 
+    integrationTestImplementation project(':gateway-eclipse-store')
     integrationTestImplementation project(':gateway-filesystem')
     integrationTestImplementation project(':gateway-inmemory')
     integrationTestImplementation project(':gateway-postgresql-jooq')
     integrationTestImplementation project(':gateway-redis')
     integrationTestImplementation project(':messaging-inmemory')
+
+    integrationTestImplementation "org.eclipse.store:storage-embedded:${eclipseStoreVersion}"
 
     integrationTestImplementation "redis.clients:jedis:${jedisVersion}"
 
@@ -60,4 +63,7 @@ tasks.register('integrationTest', Test) {
     systemProperty("cucumber.plugin", "message:build/reports/cucumber.ndjson, timeline:build/reports/timeline, html:build/reports/cucumber.html")
 
     useJUnitPlatform()
+
+    // Required to allow testing of eclipse store based gateways
+    jvmArgs = ['--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED']
 }

--- a/boundary-acceptance-test/src/integrationTest/resources/features/complete-todo.feature
+++ b/boundary-acceptance-test/src/integrationTest/resources/features/complete-todo.feature
@@ -13,6 +13,11 @@ Feature: Complete ToDo
 
     Then the todo update should have failed with the message: 'The value may not be null'
 
+    @eclipse-store
+    Examples:
+      | backend       |
+      | eclipse-store |
+
     @redis
     Examples:
       | backend |
@@ -41,6 +46,11 @@ Feature: Complete ToDo
     When I try to complete the ToDo
 
     Then the todo update should have failed with the message: 'The value may not be empty'
+
+    @eclipse-store
+    Examples:
+      | backend       |
+      | eclipse-store |
 
     @redis
     Examples:
@@ -71,6 +81,11 @@ Feature: Complete ToDo
     When I try to complete the ToDo
 
     Then the todo update should have failed with the message: 'The ToDo does not exist'
+
+    @eclipse-store
+    Examples:
+      | backend       |
+      | eclipse-store |
 
     @redis
     Examples:
@@ -105,6 +120,11 @@ Feature: Complete ToDo
 
     Then the todo update should have failed with the message: 'The ToDo cannot be completed in its current state'
 
+    @eclipse-store
+    Examples:
+      | backend       |
+      | eclipse-store |
+
     @redis
     Examples:
       | backend |
@@ -138,6 +158,11 @@ Feature: Complete ToDo
 
     Then the todo update should have been successful
 
+    @eclipse-store
+    Examples:
+      | backend       |
+      | eclipse-store |
+
     @redis
     Examples:
       | backend |
@@ -152,7 +177,7 @@ Feature: Complete ToDo
     Examples:
       | backend    |
       | filesystem |
-    
+
     @postgresql
     Examples:
       | backend    |

--- a/boundary-acceptance-test/src/integrationTest/resources/features/create-todo.feature
+++ b/boundary-acceptance-test/src/integrationTest/resources/features/create-todo.feature
@@ -14,6 +14,11 @@ Feature: Create ToDo
 
     Then creating the todo should have failed with the message 'The value may not be null'
 
+    @eclipse-store
+    Examples:
+      | backend       |
+      | eclipse-store |
+
     @redis
     Examples:
       | backend |
@@ -45,6 +50,11 @@ Feature: Create ToDo
 
     Then creating the todo should have failed with the message 'The value may not be null'
 
+    @eclipse-store
+    Examples:
+      | backend       |
+      | eclipse-store |
+
     @redis
     Examples:
       | backend |
@@ -74,6 +84,11 @@ Feature: Create ToDo
     When I try to create the todo
 
     Then creating the todo should have succeeded
+
+    @eclipse-store
+    Examples:
+      | backend       |
+      | eclipse-store |
 
     @redis
     Examples:

--- a/boundary-acceptance-test/src/integrationTest/resources/features/delete-todo.feature
+++ b/boundary-acceptance-test/src/integrationTest/resources/features/delete-todo.feature
@@ -14,6 +14,11 @@ Feature: Delete ToDo
 
     Then the todo update should have failed with the message: 'The value may not be null'
 
+    @eclipse-store
+    Examples:
+      | backend       |
+      | eclipse-store |
+
     @redis
     Examples:
       | backend |
@@ -43,6 +48,11 @@ Feature: Delete ToDo
     When I try to delete the ToDo
 
     Then the todo update should have failed with the message: 'The value may not be empty'
+
+    @eclipse-store
+    Examples:
+      | backend       |
+      | eclipse-store |
 
     @redis
     Examples:
@@ -74,6 +84,11 @@ Feature: Delete ToDo
     When I try to delete the ToDo
 
     Then the todo update should have failed with the message: 'The ToDo does not exist'
+
+    @eclipse-store
+    Examples:
+      | backend       |
+      | eclipse-store |
 
     @redis
     Examples:
@@ -113,6 +128,11 @@ Feature: Delete ToDo
     When I try to fetch the ToDo
 
     Then fetching the ToDo should have failed with the message: 'The ToDo does not exist'
+
+    @eclipse-store
+    Examples:
+      | backend       |
+      | eclipse-store |
 
     @redis
     Examples:

--- a/boundary-acceptance-test/src/integrationTest/resources/features/fetch-todo-list.feature
+++ b/boundary-acceptance-test/src/integrationTest/resources/features/fetch-todo-list.feature
@@ -14,6 +14,11 @@ Feature: Fetch todo list
 
     Then the ToDo list should be empty
 
+    @eclipse-store
+    Examples:
+      | backend       |
+      | eclipse-store |
+
     @redis
     Examples:
       | backend |
@@ -47,6 +52,11 @@ Feature: Fetch todo list
     Then the ToDo list should contain the following ToDos
       | identity | headline | description | created             | last modified       | state |
       | 42       | Test     | Lorem ipsum | 2022-01-01T12:00:00 | 2022-01-01T13:00:00 | OPEN  |
+
+    @eclipse-store
+    Examples:
+      | backend       |
+      | eclipse-store |
 
     @redis
     Examples:

--- a/boundary-acceptance-test/src/integrationTest/resources/features/fetch-todo.feature
+++ b/boundary-acceptance-test/src/integrationTest/resources/features/fetch-todo.feature
@@ -14,6 +14,11 @@ Feature: Fetch ToDo
 
     Then fetching the ToDo should have failed with the message: 'The value may not be null'
 
+    @eclipse-store
+    Examples:
+      | backend       |
+      | eclipse-store |
+
     @redis
     Examples:
       | backend |
@@ -43,6 +48,11 @@ Feature: Fetch ToDo
     When I try to fetch the ToDo
 
     Then fetching the ToDo should have failed with the message: 'The value may not be empty'
+
+    @eclipse-store
+    Examples:
+      | backend       |
+      | eclipse-store |
 
     @redis
     Examples:
@@ -74,6 +84,11 @@ Feature: Fetch ToDo
     When I try to fetch the ToDo
 
     Then fetching the ToDo should have failed with the message: 'The ToDo does not exist'
+
+    @eclipse-store
+    Examples:
+      | backend       |
+      | eclipse-store |
 
     @redis
     Examples:
@@ -109,6 +124,11 @@ Feature: Fetch ToDo
     Then the fetched Todo should have the following values:
       | identity | headline | description | created             | last modified       | state |
       | 42       | Test     | Lorem ipsum | 2022-01-01T12:00:00 | 2022-01-01T13:00:00 | OPEN  |
+
+    @eclipse-store
+    Examples:
+      | backend       |
+      | eclipse-store |
 
     @redis
     Examples:

--- a/boundary-acceptance-test/src/integrationTest/resources/features/purge-old-todos.feature
+++ b/boundary-acceptance-test/src/integrationTest/resources/features/purge-old-todos.feature
@@ -22,6 +22,11 @@ Feature: Purge Old ToDos
 
     Then fetching the ToDo should have failed with the message: 'The ToDo does not exist'
 
+    @eclipse-store
+    Examples:
+      | backend       |
+      | eclipse-store |
+
     @redis
     Examples:
       | backend |

--- a/boundary-acceptance-test/src/integrationTest/resources/features/reset-todo.feature
+++ b/boundary-acceptance-test/src/integrationTest/resources/features/reset-todo.feature
@@ -14,6 +14,11 @@ Feature: Reset ToDo
 
     Then the todo update should have failed with the message: 'The value may not be null'
 
+    @eclipse-store
+    Examples:
+      | backend       |
+      | eclipse-store |
+
     @redis
     Examples:
       | backend |
@@ -43,6 +48,11 @@ Feature: Reset ToDo
     When I try to reset the ToDo
 
     Then the todo update should have failed with the message: 'The value may not be empty'
+
+    @eclipse-store
+    Examples:
+      | backend       |
+      | eclipse-store |
 
     @redis
     Examples:
@@ -74,6 +84,11 @@ Feature: Reset ToDo
     When I try to reset the ToDo
 
     Then the todo update should have failed with the message: 'The ToDo does not exist'
+
+    @eclipse-store
+    Examples:
+      | backend       |
+      | eclipse-store |
 
     @redis
     Examples:
@@ -108,6 +123,11 @@ Feature: Reset ToDo
 
     Then the todo update should have failed with the message: 'The ToDo cannot be reset in its current state'
 
+    @eclipse-store
+    Examples:
+      | backend       |
+      | eclipse-store |
+
     @redis
     Examples:
       | backend |
@@ -140,6 +160,11 @@ Feature: Reset ToDo
     When I try to reset the ToDo
 
     Then the todo update should have been successful
+
+    @eclipse-store
+    Examples:
+      | backend       |
+      | eclipse-store |
 
     @redis
     Examples:

--- a/boundary-acceptance-test/src/integrationTest/resources/features/update-todo.feature
+++ b/boundary-acceptance-test/src/integrationTest/resources/features/update-todo.feature
@@ -14,6 +14,11 @@ Feature: Update ToDo
 
     Then the todo update should have failed with the message: 'The value may not be null'
 
+    @eclipse-store
+    Examples:
+      | backend       |
+      | eclipse-store |
+
     @redis
     Examples:
       | backend |
@@ -46,6 +51,11 @@ Feature: Update ToDo
     When I try to update the ToDo
 
     Then the todo update should have failed with the message: 'The ToDo does not exist'
+
+    @eclipse-store
+    Examples:
+      | backend       |
+      | eclipse-store |
 
     @redis
     Examples:
@@ -82,6 +92,11 @@ Feature: Update ToDo
 
     Then the todo update should have failed with the message: 'The ToDo cannot be updated in its current state'
 
+    @eclipse-store
+    Examples:
+      | backend       |
+      | eclipse-store |
+
     @redis
     Examples:
       | backend |
@@ -116,6 +131,11 @@ Feature: Update ToDo
     When I try to update the ToDo
 
     Then the todo update should have been successful
+
+    @eclipse-store
+    Examples:
+      | backend       |
+      | eclipse-store |
 
     @redis
     Examples:

--- a/gateway-acceptance-test/build.gradle
+++ b/gateway-acceptance-test/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     implementation "org.jooq:jooq:${jooqVersion}"
     implementation "org.flywaydb:flyway-core:${flywayVersion}"
 
+    integrationTestImplementation project(':gateway-eclipse-store')
     integrationTestImplementation project(':gateway-filesystem')
     integrationTestImplementation project(':gateway-inmemory')
     integrationTestImplementation project(':gateway-postgresql-jooq')
@@ -55,4 +56,7 @@ tasks.register('integrationTest', Test) {
     shouldRunAfter test
 
     useJUnitPlatform()
+
+    // Required to allow testing of eclipse store based gateways
+    jvmArgs = ['--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED']
 }

--- a/gateway-acceptance-test/src/integrationTest/java/pendenzenliste/todos/cucumber/ToDoGatewayAcceptanceTestSteps.java
+++ b/gateway-acceptance-test/src/integrationTest/java/pendenzenliste/todos/cucumber/ToDoGatewayAcceptanceTestSteps.java
@@ -14,6 +14,7 @@ import pendenzenliste.gateway.postgresql.PostgreSQLToDoGateway;
 import pendenzenliste.gateway.redis.RedisToDoGateway;
 import pendenzenliste.messaging.EventBus;
 import pendenzenliste.todos.gateway.ToDoGateway;
+import pendenzenliste.todos.gateway.eclipsestore.EclipseStoreToDoGatewayProvider;
 import pendenzenliste.todos.gateway.filesystem.FilesystemToDoGateway;
 import pendenzenliste.todos.model.*;
 import redis.clients.jedis.Jedis;
@@ -55,12 +56,14 @@ public class ToDoGatewayAcceptanceTestSteps {
     @Given("that I configure the application to use the {string} todo gateway")
     public void givenThatIConfigureTheApplicationToUseTheBackendTodoGateway(final String type) {
         switch (type) {
+            case "eclipse-store" -> this.gateway = createEclipseStoreGateway();
             case "redis" -> this.gateway = createRedisGateway();
             case "inmemory" -> this.gateway = createInMemoryGateway();
             case "filesystem" -> this.gateway = createFilesystemGateway();
             case "postgresql" -> this.gateway = createPostgreSQLGateway();
 
-            default -> throw new IllegalStateException("Unexpected value: " + type);
+            default ->
+                    throw new IllegalStateException("Unexpected value: " + type);
         }
     }
 
@@ -130,6 +133,16 @@ public class ToDoGatewayAcceptanceTestSteps {
      */
     private ToDoGateway createInMemoryGateway() {
         return new InMemoryToDoGateway(EventBus.defaultEventBus());
+    }
+
+
+    /**
+     * Creates an eclipse store gateway.
+     *
+     * @return The eclipse store gateway.
+     */
+    private ToDoGateway createEclipseStoreGateway() {
+        return new EclipseStoreToDoGatewayProvider().getInstance();
     }
 
     /**

--- a/gateway-acceptance-test/src/integrationTest/resources/features/todos/delete-todo.feature
+++ b/gateway-acceptance-test/src/integrationTest/resources/features/todos/delete-todo.feature
@@ -15,11 +15,12 @@ Feature: Delete todo
     Then deleting the todo should have failed
 
     Examples:
-      | backend    |
-      | redis      |
-      | inmemory   |
-      | filesystem |
-      | postgresql |
+      | backend       |
+      | eclipse-store |
+      | redis         |
+      | inmemory      |
+      | filesystem    |
+      | postgresql    |
 
   Scenario Outline: Delete existing todo - <backend>
 
@@ -34,8 +35,9 @@ Feature: Delete todo
     Then deleting the todo should have succeeded
 
     Examples:
-      | backend    |
-      | redis      |
-      | inmemory   |
-      | filesystem |
-      | postgresql |
+      | backend       |
+      | eclipse-store |
+      | redis         |
+      | inmemory      |
+      | filesystem    |
+      | postgresql    |

--- a/gateway-acceptance-test/src/integrationTest/resources/features/todos/fetch-todo.feature
+++ b/gateway-acceptance-test/src/integrationTest/resources/features/todos/fetch-todo.feature
@@ -15,11 +15,12 @@ Feature: Fetch todo
     Then I should have received no todo
 
     Examples:
-      | backend    |
-      | inmemory   |
-      | filesystem |
-      | redis      |
-      | postgresql |
+      | backend       |
+      | eclipse-store |
+      | inmemory      |
+      | filesystem    |
+      | redis         |
+      | postgresql    |
 
   Scenario Outline: Todo exists - <backend>
 
@@ -37,8 +38,9 @@ Feature: Fetch todo
       | 42       | Take out the trash |             | 2023-01-01T00:00:00.000 | 2023-01-01T00:00:00.000 |           | OPEN  |
 
     Examples:
-      | backend    |
-      | inmemory   |
-      | filesystem |
-      | redis      |
-      | postgresql |
+      | backend       |
+      | eclipse-store |
+      | inmemory      |
+      | filesystem    |
+      | redis         |
+      | postgresql    |

--- a/gateway-eclipse-store/build.gradle
+++ b/gateway-eclipse-store/build.gradle
@@ -1,0 +1,7 @@
+dependencies {
+    implementation project(':domain')
+    implementation project(':gateway')
+    implementation project(':messaging')
+
+    implementation "org.eclipse.store:storage-embedded:${eclipseStoreVersion}"
+}

--- a/gateway-eclipse-store/settings.gradle
+++ b/gateway-eclipse-store/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = 'gateway-eclipse-store'
+

--- a/gateway-eclipse-store/src/main/java/module-info.java
+++ b/gateway-eclipse-store/src/main/java/module-info.java
@@ -1,0 +1,8 @@
+module pendenzenliste.gateway.eclipse.store.main {
+    requires pendenzenliste.supporting.domain.achievements.main;
+    requires pendenzenliste.core.domain.todos.main;
+    requires pendenzenliste.gateway.main;
+    requires pendenzenliste.messaging.main;
+    requires org.eclipse.store.storage;
+    requires org.eclipse.store.storage.embedded;
+}

--- a/gateway-eclipse-store/src/main/java/pendenzenliste/achievements/gateway/eclipsestore/AchievementsStore.java
+++ b/gateway-eclipse-store/src/main/java/pendenzenliste/achievements/gateway/eclipsestore/AchievementsStore.java
@@ -1,0 +1,35 @@
+package pendenzenliste.achievements.gateway.eclipsestore;
+
+import pendenzenliste.achievements.model.AchievementAggregate;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * The achievements store used for integration with eclipse store.
+ */
+public class AchievementsStore {
+
+    private final Collection<AchievementAggregate> achievements =
+            new ArrayList<>();
+
+    /**
+     * Retrieves the achievements.
+     *
+     * @return The achievements.
+     */
+    public List<AchievementAggregate> getAchievements() {
+        return new ArrayList<>(achievements);
+    }
+
+    /**
+     * Sets the achievements.
+     *
+     * @param achievements The achievements.
+     */
+    public void setAchievements(final Collection<AchievementAggregate> achievements) {
+        this.achievements.clear();
+        this.achievements.addAll(achievements);
+    }
+}

--- a/gateway-eclipse-store/src/main/java/pendenzenliste/achievements/gateway/eclipsestore/EclipseStoreAchievementGateway.java
+++ b/gateway-eclipse-store/src/main/java/pendenzenliste/achievements/gateway/eclipsestore/EclipseStoreAchievementGateway.java
@@ -1,0 +1,111 @@
+package pendenzenliste.achievements.gateway.eclipsestore;
+
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import pendenzenliste.achievements.gateway.AchievementGateway;
+import pendenzenliste.achievements.model.*;
+import pendenzenliste.messaging.EventBus;
+
+import java.util.*;
+import java.util.stream.Stream;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * An implementation of the {@link AchievementGateway} that makes use of the eclipse
+ * store library to provide persistence.
+ */
+public class EclipseStoreAchievementGateway implements AchievementGateway {
+
+    private final EmbeddedStorageManager storageManager;
+    private final EventBus eventBus;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param storageManager The storage manager.
+     * @param eventBus       The event bus.
+     */
+    public EclipseStoreAchievementGateway(final EmbeddedStorageManager storageManager,
+                                          final EventBus eventBus) {
+        this.storageManager = requireNonNull(storageManager, "The storage manager may not be null");
+        this.eventBus = requireNonNull(eventBus, "The event bus may not be null");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Optional<AchievementAggregate> findById(final IdentityValueObject identity) {
+        return getStore().getAchievements()
+                .stream()
+                .filter(achievement ->
+                        Objects.equals(achievement.aggregateRoot().identity(), identity))
+                .findFirst();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Stream<AchievementAggregate> fetchAll() {
+        return getStore().getAchievements().stream();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Stream<AchievementAggregate> fetchLockedAchievements() {
+        return fetchAll().filter(achievement -> StateValueType.LOCKED.equals(achievement.aggregateRoot().state()));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void store(final AchievementAggregate achievement) {
+        final Collection<AchievementEvent> unpublishedEvents =
+                new ArrayList<>();
+
+        for (final AchievementEventEntity event :
+                achievement.events()
+                        .stream()
+                        .filter(event -> event.identity() == null)
+                        .toList()) {
+            final var unpublishedEvent =
+                    event.withIdentity(IdentityValueObject.random());
+
+            achievement.replaceEvent(event, unpublishedEvent);
+            unpublishedEvents.add(unpublishedEvent.event());
+        }
+
+        final AchievementsStore store = getStore();
+
+        final List<AchievementAggregate> achievements =
+                store.getAchievements();
+
+        if (achievements.contains(achievement)) {
+            final int index = achievements.indexOf(achievement);
+            achievements.set(index, achievement);
+        } else {
+            achievements.add(achievement);
+        }
+
+        store.setAchievements(achievements);
+        storageManager.setRoot(store);
+        storageManager.storeRoot();
+
+        unpublishedEvents.forEach(eventBus::publish);
+    }
+
+    /**
+     * Retrieves the store.
+     *
+     * @return The store.
+     */
+    private AchievementsStore getStore() {
+        return Optional.ofNullable(storageManager.root())
+                .map(r -> (AchievementsStore) r)
+                .orElse(new AchievementsStore());
+    }
+}

--- a/gateway-eclipse-store/src/main/java/pendenzenliste/achievements/gateway/eclipsestore/EclipseStoreAchievementGatewayProvider.java
+++ b/gateway-eclipse-store/src/main/java/pendenzenliste/achievements/gateway/eclipsestore/EclipseStoreAchievementGatewayProvider.java
@@ -1,0 +1,38 @@
+package pendenzenliste.achievements.gateway.eclipsestore;
+
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import pendenzenliste.achievements.gateway.AchievementGateway;
+import pendenzenliste.achievements.gateway.AchievementGatewayProvider;
+import pendenzenliste.messaging.EventBus;
+
+import java.io.IOException;
+import java.nio.file.Files;
+
+@Deprecated(forRemoval = true)
+public class EclipseStoreAchievementGatewayProvider implements AchievementGatewayProvider {
+
+    private static final EclipseStoreAchievementGateway INSTANCE;
+
+    static {
+        try {
+            final var storageManager = EmbeddedStorage.start(
+                    Files.createTempDirectory("achievements")
+            );
+
+            storageManager.storeRoot();
+
+            INSTANCE = new EclipseStoreAchievementGateway(storageManager,
+                    EventBus.defaultEventBus());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public AchievementGateway getInstance() {
+        return INSTANCE;
+    }
+}

--- a/gateway-eclipse-store/src/main/java/pendenzenliste/todos/gateway/eclipsestore/EclipseStoreToDoGatewayProvider.java
+++ b/gateway-eclipse-store/src/main/java/pendenzenliste/todos/gateway/eclipsestore/EclipseStoreToDoGatewayProvider.java
@@ -1,0 +1,38 @@
+package pendenzenliste.todos.gateway.eclipsestore;
+
+import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
+import pendenzenliste.messaging.EventBus;
+import pendenzenliste.todos.gateway.ToDoGateway;
+import pendenzenliste.todos.gateway.ToDoGatewayProvider;
+
+import java.io.IOException;
+import java.nio.file.Files;
+
+@Deprecated(forRemoval = true)
+public class EclipseStoreToDoGatewayProvider implements ToDoGatewayProvider {
+
+    private static final EclipseStoreTodoGateway INSTANCE;
+
+    static {
+        try {
+            final var storageManager = EmbeddedStorage.start(
+                    Files.createTempDirectory("todos")
+            );
+
+            storageManager.storeRoot();
+
+            INSTANCE = new EclipseStoreTodoGateway(storageManager,
+                    EventBus.defaultEventBus());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ToDoGateway getInstance() {
+        return INSTANCE;
+    }
+}

--- a/gateway-eclipse-store/src/main/java/pendenzenliste/todos/gateway/eclipsestore/EclipseStoreTodoGateway.java
+++ b/gateway-eclipse-store/src/main/java/pendenzenliste/todos/gateway/eclipsestore/EclipseStoreTodoGateway.java
@@ -1,0 +1,123 @@
+package pendenzenliste.todos.gateway.eclipsestore;
+
+import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
+import pendenzenliste.messaging.EventBus;
+import pendenzenliste.todos.gateway.ToDoGateway;
+import pendenzenliste.todos.model.IdentityValueObject;
+import pendenzenliste.todos.model.ToDoAggregate;
+import pendenzenliste.todos.model.ToDoDeletedEvent;
+import pendenzenliste.todos.model.ToDoEntity;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * An implementation of the {@link ToDoGateway} that makes use of the eclipse
+ * store library to provide persistence.
+ */
+public class EclipseStoreTodoGateway implements ToDoGateway {
+    private final EmbeddedStorageManager storageManager;
+    private final EventBus eventBus;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param storageManager The storage manager.
+     * @param eventBus       The event bus.
+     */
+    public EclipseStoreTodoGateway(final EmbeddedStorageManager storageManager, final EventBus eventBus) {
+        this.storageManager = requireNonNull(storageManager, "The storage manager may not be null");
+        this.eventBus = requireNonNull(eventBus, "The event bus may not be null");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Optional<ToDoAggregate> findById(final IdentityValueObject id) {
+        return getStore().getTodos().stream()
+                .filter(todo -> Objects.equals(todo.identity(), id))
+                .map(todo -> new ToDoAggregate(todo, this, eventBus))
+                .findFirst();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean delete(final IdentityValueObject id) {
+        final ToDoStore store = getStore();
+        final List<ToDoEntity> todos = store.getTodos();
+
+        final Optional<ToDoEntity> todo =
+                todos.stream().filter(t -> Objects.equals(t.identity(), id))
+                        .findFirst();
+
+        if (todo.isPresent()) {
+            todos.remove(todo.get());
+            store.setTodos(todos);
+            storageManager.setRoot(store);
+            storageManager.storeRoot();
+            eventBus.publish(new ToDoDeletedEvent(LocalDateTime.now(), id));
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Stream<ToDoAggregate> fetchAll() {
+        return getStore().getTodos().stream().map(todo -> new ToDoAggregate(todo, this, eventBus));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Stream<ToDoAggregate> fetchAllCompletedBefore(final LocalDateTime timestamp) {
+        return fetchAll().filter(todo -> todo.aggregateRoot().isClosed())
+                .filter(todo -> todo.aggregateRoot().completed().isBefore(timestamp));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void store(final ToDoAggregate todo) {
+        final Optional<ToDoAggregate> existingToDo =
+                findById(todo.aggregateRoot().identity());
+
+        final ToDoStore store = getStore();
+
+        final List<ToDoEntity> todos = store.getTodos();
+
+        if (existingToDo.isPresent()) {
+            final int index = todos.indexOf(existingToDo.get().aggregateRoot());
+            todos.set(index, todo.aggregateRoot());
+        } else {
+            todos.add(todo.aggregateRoot());
+        }
+        store.setTodos(todos);
+        storageManager.setRoot(store);
+        storageManager.storeRoot();
+    }
+
+    /**
+     * Retrieves the store.
+     *
+     * @return The store.
+     */
+    private ToDoStore getStore() {
+        return Optional.ofNullable(storageManager.root())
+                .map(r -> (ToDoStore) r)
+                .orElse(new ToDoStore());
+    }
+}

--- a/gateway-eclipse-store/src/main/java/pendenzenliste/todos/gateway/eclipsestore/ToDoStore.java
+++ b/gateway-eclipse-store/src/main/java/pendenzenliste/todos/gateway/eclipsestore/ToDoStore.java
@@ -1,0 +1,34 @@
+package pendenzenliste.todos.gateway.eclipsestore;
+
+import pendenzenliste.todos.model.ToDoEntity;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * The todo store used for the integration with eclipse store.
+ */
+public class ToDoStore {
+
+    private List<ToDoEntity> todos = new ArrayList<>();
+
+    /**
+     * Retrieves the todos.
+     *
+     * @return The todos.
+     */
+    public List<ToDoEntity> getTodos() {
+        return new ArrayList<>(todos);
+    }
+
+    /**
+     * Sets the todos.
+     *
+     * @param todos The todos.
+     */
+    public void setTodos(final Collection<ToDoEntity> todos) {
+        this.todos.clear();
+        this.todos.addAll(todos);
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,6 +5,7 @@ org.gradle.daemon=true
 commonsCLIVersion=1.5.0
 discord4JVersion=3.2.5
 dropwizardVersion=2.1.10
+eclipseStoreVersion=1.3.1
 flywayVersion=9.22.3
 hikariVersion=5.0.1
 jedisVersion=5.0.1

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,6 +17,7 @@ include 'domain-todos'
 
 include 'gateway'
 include 'gateway-acceptance-test'
+include 'gateway-eclipse-store'
 include 'gateway-filesystem'
 include 'gateway-inmemory'
 include 'gateway-postgresql-jooq'


### PR DESCRIPTION
This commit includes the implementation of Eclipse Store based ToDo and Achievement gateways. These gateways are used to interact with the Eclipse Store for persistence of ToDo and Achievement items. It also contains the necessary gradle file for building the implementation.

https://github.com/flens-dev/pendenzenliste/issues/78