### PR TITLE
Add support for different PostgreSQL versions in tests

### DIFF
--- a/boundary-acceptance-test/src/integrationTest/java/pendenzenliste/boundary/cucumber/ToDoGatewayFactory.java
+++ b/boundary-acceptance-test/src/integrationTest/java/pendenzenliste/boundary/cucumber/ToDoGatewayFactory.java
@@ -6,6 +6,8 @@ import org.jooq.impl.DSL;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.utility.DockerImageName;
+import pendenzenliste.acceptancetests.ToolVersion;
+import pendenzenliste.acceptancetests.VersionParser;
 import pendenzenliste.gateway.inmemory.InMemoryToDoGateway;
 import pendenzenliste.gateway.postgresql.PostgreSQLToDoGateway;
 import pendenzenliste.gateway.redis.RedisToDoGateway;
@@ -47,7 +49,9 @@ public class ToDoGatewayFactory {
      * @return The todo gateway.
      */
     public ToDoGateway create(final String type) {
-        switch (type) {
+        ToolVersion toolVersion = VersionParser.parse(type);
+
+        switch (toolVersion.tool()) {
             case "redis":
                 return createRedisGateway();
 
@@ -58,7 +62,7 @@ public class ToDoGatewayFactory {
                 return createFilesystemGateway();
 
             case "postgresql":
-                return createPostgreSQLGateway();
+                return createPostgreSQLGateway(toolVersion);
 
             case "eclipse-store":
                 return createEclipseStoreGateway();
@@ -92,8 +96,11 @@ public class ToDoGatewayFactory {
      *
      * @return The PostgreSQL gateway.
      */
-    private ToDoGateway createPostgreSQLGateway() {
-        final var postgresql = new PostgreSQLContainer<>("postgres:15.4-alpine3.18")
+    private ToDoGateway createPostgreSQLGateway(final ToolVersion toolVersion) {
+        final String version = toolVersion.version()
+                .orElseThrow(() -> new IllegalArgumentException("Missing version parameter: " + toolVersion));
+
+        final var postgresql = new PostgreSQLContainer<>("postgres:" + version)
                 .withDatabaseName("pendenzenliste");
 
         postgresql.start();

--- a/boundary-acceptance-test/src/integrationTest/resources/features/complete-todo.feature
+++ b/boundary-acceptance-test/src/integrationTest/resources/features/complete-todo.feature
@@ -35,8 +35,11 @@ Feature: Complete ToDo
 
     @postgresql
     Examples:
-      | backend    |
-      | postgresql |
+      | backend          |
+      | postgresql:16.2  |
+      | postgresql:15.6  |
+      | postgresql:14.11 |
+      | postgresql:13.14 |
 
   Scenario Outline: Empty ID - <backend>
 
@@ -69,8 +72,11 @@ Feature: Complete ToDo
 
     @postgresql
     Examples:
-      | backend    |
-      | postgresql |
+      | backend          |
+      | postgresql:16.2  |
+      | postgresql:15.6  |
+      | postgresql:14.11 |
+      | postgresql:13.14 |
 
   Scenario Outline: ToDo does not exist - <backend>
 
@@ -104,8 +110,11 @@ Feature: Complete ToDo
 
     @postgresql
     Examples:
-      | backend    |
-      | postgresql |
+      | backend          |
+      | postgresql:16.2  |
+      | postgresql:15.6  |
+      | postgresql:14.11 |
+      | postgresql:13.14 |
 
   Scenario Outline: ToDo is already completed - <backend>
 
@@ -142,8 +151,11 @@ Feature: Complete ToDo
 
     @postgresql
     Examples:
-      | backend    |
-      | postgresql |
+      | backend          |
+      | postgresql:16.2  |
+      | postgresql:15.6  |
+      | postgresql:14.11 |
+      | postgresql:13.14 |
 
   Scenario Outline: Successful update - <backend>
 
@@ -180,5 +192,8 @@ Feature: Complete ToDo
 
     @postgresql
     Examples:
-      | backend    |
-      | postgresql |
+      | backend          |
+      | postgresql:16.2  |
+      | postgresql:15.6  |
+      | postgresql:14.11 |
+      | postgresql:13.14 |

--- a/boundary-acceptance-test/src/integrationTest/resources/features/create-todo.feature
+++ b/boundary-acceptance-test/src/integrationTest/resources/features/create-todo.feature
@@ -36,8 +36,11 @@ Feature: Create ToDo
 
     @postgresql
     Examples:
-      | backend    |
-      | postgresql |
+      | backend          |
+      | postgresql:16.2  |
+      | postgresql:15.6  |
+      | postgresql:14.11 |
+      | postgresql:13.14 |
 
   Scenario Outline: No description - <backend>
 
@@ -72,8 +75,11 @@ Feature: Create ToDo
 
     @postgresql
     Examples:
-      | backend    |
-      | postgresql |
+      | backend          |
+      | postgresql:16.2  |
+      | postgresql:15.6  |
+      | postgresql:14.11 |
+      | postgresql:13.14 |
 
   Scenario Outline: Successful creation - <backend>
     Given that I configure the application to use the '<backend>' todo gateway
@@ -104,8 +110,11 @@ Feature: Create ToDo
     Examples:
       | backend    |
       | filesystem |
-    
+
     @postgresql
     Examples:
-      | backend    |
-      | postgresql |
+      | backend          |
+      | postgresql:16.2  |
+      | postgresql:15.6  |
+      | postgresql:14.11 |
+      | postgresql:13.14 |

--- a/boundary-acceptance-test/src/integrationTest/resources/features/delete-todo.feature
+++ b/boundary-acceptance-test/src/integrationTest/resources/features/delete-todo.feature
@@ -36,8 +36,11 @@ Feature: Delete ToDo
 
     @postgresql
     Examples:
-      | backend    |
-      | postgresql |
+      | backend          |
+      | postgresql:16.2  |
+      | postgresql:15.6  |
+      | postgresql:14.11 |
+      | postgresql:13.14 |
 
   Scenario Outline: Empty ID - <backend>
 
@@ -71,8 +74,11 @@ Feature: Delete ToDo
 
     @postgresql
     Examples:
-      | backend    |
-      | postgresql |
+      | backend          |
+      | postgresql:16.2  |
+      | postgresql:15.6  |
+      | postgresql:14.11 |
+      | postgresql:13.14 |
 
   Scenario Outline: ToDo does not exist - <backend>
 
@@ -107,8 +113,11 @@ Feature: Delete ToDo
 
     @postgresql
     Examples:
-      | backend    |
-      | postgresql |
+      | backend          |
+      | postgresql:16.2  |
+      | postgresql:15.6  |
+      | postgresql:14.11 |
+      | postgresql:13.14 |
 
   Scenario Outline: Deleting the ToDo succeeds - <backend>
 
@@ -148,8 +157,11 @@ Feature: Delete ToDo
     Examples:
       | backend    |
       | filesystem |
-    
+
     @postgresql
     Examples:
-      | backend    |
-      | postgresql |
+      | backend          |
+      | postgresql:16.2  |
+      | postgresql:15.6  |
+      | postgresql:14.11 |
+      | postgresql:13.14 |

--- a/boundary-acceptance-test/src/integrationTest/resources/features/fetch-todo-list.feature
+++ b/boundary-acceptance-test/src/integrationTest/resources/features/fetch-todo-list.feature
@@ -36,8 +36,11 @@ Feature: Fetch todo list
 
     @postgresql
     Examples:
-      | backend    |
-      | postgresql |
+      | backend          |
+      | postgresql:16.2  |
+      | postgresql:15.6  |
+      | postgresql:14.11 |
+      | postgresql:13.14 |
 
   Scenario Outline: Some ToDos exist - <backend>
 
@@ -75,5 +78,8 @@ Feature: Fetch todo list
 
     @postgresql
     Examples:
-      | backend    |
-      | postgresql |
+      | backend          |
+      | postgresql:16.2  |
+      | postgresql:15.6  |
+      | postgresql:14.11 |
+      | postgresql:13.14 |

--- a/boundary-acceptance-test/src/integrationTest/resources/features/fetch-todo.feature
+++ b/boundary-acceptance-test/src/integrationTest/resources/features/fetch-todo.feature
@@ -36,8 +36,11 @@ Feature: Fetch ToDo
 
     @postgresql
     Examples:
-      | backend    |
-      | postgresql |
+      | backend          |
+      | postgresql:16.2  |
+      | postgresql:15.6  |
+      | postgresql:14.11 |
+      | postgresql:13.14 |
 
   Scenario Outline: Empty ID - <backend>
 
@@ -71,8 +74,11 @@ Feature: Fetch ToDo
 
     @postgresql
     Examples:
-      | backend    |
-      | postgresql |
+      | backend          |
+      | postgresql:16.2  |
+      | postgresql:15.6  |
+      | postgresql:14.11 |
+      | postgresql:13.14 |
 
   Scenario Outline: ToDo does not exist - <backend>
 
@@ -107,8 +113,11 @@ Feature: Fetch ToDo
 
     @postgresql
     Examples:
-      | backend    |
-      | postgresql |
+      | backend          |
+      | postgresql:16.2  |
+      | postgresql:15.6  |
+      | postgresql:14.11 |
+      | postgresql:13.14 |
 
   Scenario Outline: ToDo exists - <backend>
 
@@ -144,8 +153,11 @@ Feature: Fetch ToDo
     Examples:
       | backend    |
       | filesystem |
-    
+
     @postgresql
     Examples:
-      | backend    |
-      | postgresql |
+      | backend          |
+      | postgresql:16.2  |
+      | postgresql:15.6  |
+      | postgresql:14.11 |
+      | postgresql:13.14 |

--- a/boundary-acceptance-test/src/integrationTest/resources/features/purge-old-todos.feature
+++ b/boundary-acceptance-test/src/integrationTest/resources/features/purge-old-todos.feature
@@ -44,5 +44,8 @@ Feature: Purge Old ToDos
 
     @postgresql
     Examples:
-      | backend    |
-      | postgresql |
+      | backend          |
+      | postgresql:16.2  |
+      | postgresql:15.6  |
+      | postgresql:14.11 |
+      | postgresql:13.14 |

--- a/boundary-acceptance-test/src/integrationTest/resources/features/reset-todo.feature
+++ b/boundary-acceptance-test/src/integrationTest/resources/features/reset-todo.feature
@@ -36,8 +36,11 @@ Feature: Reset ToDo
 
     @postgresql
     Examples:
-      | backend    |
-      | postgresql |
+      | backend          |
+      | postgresql:16.2  |
+      | postgresql:15.6  |
+      | postgresql:14.11 |
+      | postgresql:13.14 |
 
   Scenario Outline: Empty ID - <backend>
 
@@ -71,8 +74,11 @@ Feature: Reset ToDo
 
     @postgresql
     Examples:
-      | backend    |
-      | postgresql |
+      | backend          |
+      | postgresql:16.2  |
+      | postgresql:15.6  |
+      | postgresql:14.11 |
+      | postgresql:13.14 |
 
   Scenario Outline: ToDo does not exist - <backend>
 
@@ -107,8 +113,11 @@ Feature: Reset ToDo
 
     @postgresql
     Examples:
-      | backend    |
-      | postgresql |
+      | backend          |
+      | postgresql:16.2  |
+      | postgresql:15.6  |
+      | postgresql:14.11 |
+      | postgresql:13.14 |
 
   Scenario Outline: ToDo is open - <backend>
 
@@ -145,9 +154,12 @@ Feature: Reset ToDo
 
     @postgresql
     Examples:
-      | backend    |
-      | postgresql |
-
+      | backend          |
+      | postgresql:16.2  |
+      | postgresql:15.6  |
+      | postgresql:14.11 |
+      | postgresql:13.14 |
+    
   Scenario Outline: Reset ToDo - <backend>
 
     Given that I configure the application to use the '<backend>' todo gateway
@@ -183,5 +195,8 @@ Feature: Reset ToDo
 
     @postgresql
     Examples:
-      | backend    |
-      | postgresql |
+      | backend          |
+      | postgresql:16.2  |
+      | postgresql:15.6  |
+      | postgresql:14.11 |
+      | postgresql:13.14 |

--- a/boundary-acceptance-test/src/integrationTest/resources/features/update-todo.feature
+++ b/boundary-acceptance-test/src/integrationTest/resources/features/update-todo.feature
@@ -36,8 +36,11 @@ Feature: Update ToDo
 
     @postgresql
     Examples:
-      | backend    |
-      | postgresql |
+      | backend          |
+      | postgresql:16.2  |
+      | postgresql:15.6  |
+      | postgresql:14.11 |
+      | postgresql:13.14 |
 
   Scenario Outline: ToDo does not exist - <backend>
 
@@ -74,8 +77,11 @@ Feature: Update ToDo
 
     @postgresql
     Examples:
-      | backend    |
-      | postgresql |
+      | backend          |
+      | postgresql:16.2  |
+      | postgresql:15.6  |
+      | postgresql:14.11 |
+      | postgresql:13.14 |
 
   Scenario Outline: ToDo has already been closed - <backend>
 
@@ -114,8 +120,11 @@ Feature: Update ToDo
 
     @postgresql
     Examples:
-      | backend    |
-      | postgresql |
+      | backend          |
+      | postgresql:16.2  |
+      | postgresql:15.6  |
+      | postgresql:14.11 |
+      | postgresql:13.14 |
 
   Scenario Outline: Successful update - <backend>
 
@@ -154,5 +163,8 @@ Feature: Update ToDo
 
     @postgresql
     Examples:
-      | backend    |
-      | postgresql |
+      | backend          |
+      | postgresql:16.2  |
+      | postgresql:15.6  |
+      | postgresql:14.11 |
+      | postgresql:13.14 |

--- a/boundary-acceptance-test/src/main/java/pendenzenliste/acceptancetests/ToolVersion.java
+++ b/boundary-acceptance-test/src/main/java/pendenzenliste/acceptancetests/ToolVersion.java
@@ -1,0 +1,12 @@
+package pendenzenliste.acceptancetests;
+
+import java.util.Optional;
+
+/**
+ * A record that can be used to represent a tool and its version.
+ *
+ * @param tool    The name of the tool that should be used.
+ * @param version The version of the tool that should be used.
+ */
+public record ToolVersion(String tool, Optional<String> version) {
+}

--- a/boundary-acceptance-test/src/main/java/pendenzenliste/acceptancetests/VersionParser.java
+++ b/boundary-acceptance-test/src/main/java/pendenzenliste/acceptancetests/VersionParser.java
@@ -1,0 +1,27 @@
+package pendenzenliste.acceptancetests;
+
+import java.util.Optional;
+
+/**
+ * A utility class that can be used to parse the version from a string.
+ * <p>
+ * This supports the format of e.g. postgres:16.2. Where
+ */
+public class VersionParser {
+
+    /**
+     * Parses the given value.
+     *
+     * @param value The value that should be parsed.
+     * @return The parsed version number.
+     */
+    public static ToolVersion parse(final String value) {
+        final String[] token = value.split(":", 2);
+
+        if (token.length == 2) {
+            return new ToolVersion(token[0], Optional.of(token[1]));
+        } else {
+            return new ToolVersion(value, Optional.empty());
+        }
+    }
+}

--- a/boundary-acceptance-test/src/test/java/pendenzenliste/acceptancetests/VersionParserTest.java
+++ b/boundary-acceptance-test/src/test/java/pendenzenliste/acceptancetests/VersionParserTest.java
@@ -1,0 +1,31 @@
+package pendenzenliste.acceptancetests;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Test;
+
+class VersionParserTest {
+
+    @Test
+    public void parse_withToolAndVersion() {
+        ToolVersion toolVersion = VersionParser.parse("tool:version");
+
+        final var assertions = new SoftAssertions();
+
+        assertions.assertThat(toolVersion.tool()).isEqualTo("tool");
+        assertions.assertThat(toolVersion.version()).hasValue("version");
+
+        assertions.assertAll();
+    }
+
+    @Test
+    public void parse_withToolAndNoVersion() {
+        ToolVersion toolVersion = VersionParser.parse("tool");
+
+        final var assertions = new SoftAssertions();
+
+        assertions.assertThat(toolVersion.tool()).isEqualTo("tool");
+        assertions.assertThat(toolVersion.version()).isEmpty();
+
+        assertions.assertAll();
+    }
+}


### PR DESCRIPTION
This commit adds support for testing with different PostgreSQL versions. A new record type, `ToolVersion`, has been introduced to handle version parsing. Additionally, the `createPostgreSQLGateway` method is updated to handle the version-specific configuration. This change allows for better coverage across different PostgreSQL versions in acceptance and integration tests.

https://github.com/flens-dev/pendenzenliste/issues/55